### PR TITLE
[#41] Feature: Added Primor scraper.

### DIFF
--- a/scraper/function/productProcessor.ts
+++ b/scraper/function/productProcessor.ts
@@ -1,8 +1,9 @@
 import { getProductsBySSN, upsertProductPrice } from './postgres';
 import { amazonScraper } from '../providers/amazon';
+import { primorScraper } from '../providers/primor';
 import { ScraperFn } from '../utils/types';
 import { Browser, chromium } from '@playwright/test';
-import {AMAZON_PROVIDER_ID,CARREFOUR_PROVIDER_ID} from '../utils/providers';
+import {AMAZON_PROVIDER_ID,CARREFOUR_PROVIDER_ID, PRIMOR_PROVIDER_ID} from '../utils/providers';
 import { carrefourScraper } from '../providers/carrefour';
 import { closeLogger, LOG_EVENT, logger, normalizeLogError } from '../utils/logger';
 
@@ -10,7 +11,8 @@ const headless = process.env.PLAYWRIGHTHEADLESS === 'True' ? true : false;
 
 const scrapers: Record<number, ScraperFn> = {
   [AMAZON_PROVIDER_ID]: amazonScraper,
-  [CARREFOUR_PROVIDER_ID]: carrefourScraper
+  [CARREFOUR_PROVIDER_ID]: carrefourScraper,
+  [PRIMOR_PROVIDER_ID]: primorScraper
 };
 
 export async function scrapeAndStoreProductPrice(

--- a/scraper/page/primor/cookiePage.ts
+++ b/scraper/page/primor/cookiePage.ts
@@ -1,0 +1,17 @@
+import { Page,Locator } from '@playwright/test';
+
+export class CookiesPage {
+  private page: Page;
+  readonly rejectButton: Locator;
+
+
+  constructor(page: Page) {
+    this.page = page;
+    this.rejectButton = page.locator('[data-dispatch-action="cookiebar-action-accept"]');
+  }
+  
+  async clickRejectButton(){
+    await this.rejectButton.click();
+  }
+
+}

--- a/scraper/page/primor/homePage.ts
+++ b/scraper/page/primor/homePage.ts
@@ -1,0 +1,32 @@
+import { Page, Locator } from '@playwright/test';
+
+export class HomePage {
+  private page: Page;
+  readonly searchInput: Locator;
+  readonly searchButton: Locator;
+  readonly searchBar: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.searchBar = page.locator('[data-test="search-input"]');
+    this.searchButton = page.locator('[data-test="search-button"]');
+  }
+  
+  async clickSearchBar(){
+    await this.searchBar.click()
+  }
+
+  async typeSearch(reference: string){
+    await this.searchBar.fill(reference)
+  }
+
+  async clickSearchButton(){
+    await this.searchButton.click()
+  }
+
+  async searchForReference(reference:string){
+    await this.clickSearchBar()
+    await this.typeSearch(reference)
+    await this.clickSearchButton()
+  }
+}

--- a/scraper/page/primor/searchListPage.ts
+++ b/scraper/page/primor/searchListPage.ts
@@ -1,0 +1,24 @@
+import { Page, Locator } from '@playwright/test';
+
+export class SearchListPage {
+  private page: Page;
+  readonly item: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.item = page.locator('[data-test="result-current-price"]').first()
+  }
+
+  async clickItem() {
+    await this.item.click();
+  }
+
+  async priceItem(): Promise<string> {
+    const price = await this.item.textContent();
+    if (price === null) {
+      throw new Error(`Price not found`);
+    }
+
+    return price;
+  }
+}

--- a/scraper/providers/primor.ts
+++ b/scraper/providers/primor.ts
@@ -1,0 +1,32 @@
+import { parsePriceToEuros } from '../function/common';
+import { LOG_EVENT, logger, normalizeLogError } from '../utils/logger';
+import { ScraperFn } from '../utils/types';
+import { CookiesPage } from '../page/primor/cookiePage';
+import { HomePage } from '../page/primor/homePage';
+import { SearchListPage } from '../page/primor/searchListPage';
+
+export const primorScraper: ScraperFn = async ({context,productId }) => {
+
+  try {
+    logger.info({ event: LOG_EVENT.PROVIDER_SCRAPE_STARTED, provider: 'primor', productId }, 'Starting Primor scraper');
+
+    const page = await context.newPage();
+    await page.goto('https://www.primor.eu/es_es/');
+    const cookiesPage = new CookiesPage(page);
+    const homePage = new HomePage(page);
+    const searchListPage = new SearchListPage(page);
+    
+    await cookiesPage.clickRejectButton();
+    await homePage.searchForReference(productId);
+    const rawPrice = await searchListPage.priceItem();
+
+    const price = parsePriceToEuros(rawPrice);
+    logger.info({ event: LOG_EVENT.PROVIDER_PRICE_OBTAINED, provider: 'primor', productId, price }, 'Price obtained from Primor');
+    return price;
+  } catch (error) {
+    logger.error({ event: LOG_EVENT.PROVIDER_SCRAPE_FAILED, provider: 'primor', productId, error: normalizeLogError(error) }, 'Primor scraper failed');
+    throw error;
+  } finally {
+    await context.close();
+  }
+};

--- a/scraper/utils/providers.ts
+++ b/scraper/utils/providers.ts
@@ -1,2 +1,3 @@
 export const AMAZON_PROVIDER_ID:number = 1;
 export const CARREFOUR_PROVIDER_ID:number = 2;
+export const PRIMOR_PROVIDER_ID:number = 3;


### PR DESCRIPTION
## Summary

Add support for **Primor** as a new price scraping provider.

## Changes

- Added `primorScraper` and registered it in the product processing flow.
- Implemented the required Page Objects for Primor.
- Added the scraping logic to:
  - Search for a product by reference.
  - Extract its price.
  - Parse the price into the internal format.
- Added the new `PRIMOR_PROVIDER_ID`.

## Impact

The scraping service now supports Primor alongside the existing providers, following the current scraper architecture.