### PR TITLE
[#42] Feature: Added Druni as a new tenant with scraper and page clases.

### DIFF
--- a/scraper/function/productProcessor.ts
+++ b/scraper/function/productProcessor.ts
@@ -1,9 +1,10 @@
 import { getProductsBySSN, upsertProductPrice } from './postgres';
 import { amazonScraper } from '../providers/amazon';
 import { primorScraper } from '../providers/primor';
+import { druniScraper } from '../providers/druni';
 import { ScraperFn } from '../utils/types';
 import { Browser, chromium } from '@playwright/test';
-import {AMAZON_PROVIDER_ID,CARREFOUR_PROVIDER_ID, PRIMOR_PROVIDER_ID} from '../utils/providers';
+import {AMAZON_PROVIDER_ID,CARREFOUR_PROVIDER_ID, PRIMOR_PROVIDER_ID, DRUNI_PROVIDER_ID} from '../utils/providers';
 import { carrefourScraper } from '../providers/carrefour';
 import { closeLogger, LOG_EVENT, logger, normalizeLogError } from '../utils/logger';
 
@@ -12,7 +13,8 @@ const headless = process.env.PLAYWRIGHTHEADLESS === 'True' ? true : false;
 const scrapers: Record<number, ScraperFn> = {
   [AMAZON_PROVIDER_ID]: amazonScraper,
   [CARREFOUR_PROVIDER_ID]: carrefourScraper,
-  [PRIMOR_PROVIDER_ID]: primorScraper
+  [PRIMOR_PROVIDER_ID]: primorScraper,
+  [DRUNI_PROVIDER_ID]: druniScraper
 };
 
 export async function scrapeAndStoreProductPrice(

--- a/scraper/page/druni/cookiesPage.ts
+++ b/scraper/page/druni/cookiesPage.ts
@@ -1,0 +1,17 @@
+import { Page,Locator } from '@playwright/test';
+
+export class CookiesPage {
+  private page: Page;
+  readonly rejectButton: Locator;
+
+
+  constructor(page: Page) {
+    this.page = page;
+    this.rejectButton = page.locator('[aria-label="Rechazar"]');
+  }
+  
+  async clickRejectButton(){
+    await this.rejectButton.click();
+  }
+
+}

--- a/scraper/page/druni/homePage.ts
+++ b/scraper/page/druni/homePage.ts
@@ -1,0 +1,39 @@
+import { Page,Locator } from '@playwright/test';
+
+export class HomePage {
+  private page: Page;
+  readonly searchInput: Locator;
+  readonly searchButton: Locator;
+  readonly searchBar: Locator;
+  readonly continueModalButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.searchBar = page.locator('#search');
+    this.searchInput = page.locator('[name="search[query]"]')
+    this.searchButton = page.locator('label[data-role="minisearch-label"]')
+    this.continueModalButton = page.getByRole('button', { name: 'Continuar' })
+  }
+
+  async clickContinueModalButton(){
+    await this.continueModalButton.click()
+  }
+  
+  async clickSearchBar(){
+    await this.searchBar.click()
+  }
+
+  async typeSearch(reference: string){
+    await this.searchInput.fill(reference)
+  }
+
+  async clickSearchButton(){
+    await this.searchButton.click()
+  }
+
+  async searchForReference(reference:string){
+    await this.clickContinueModalButton()
+    await this.clickSearchBar()
+    await this.typeSearch(reference)
+    }
+}

--- a/scraper/page/druni/searchListPage.ts
+++ b/scraper/page/druni/searchListPage.ts
@@ -1,0 +1,29 @@
+import { Page, Locator } from '@playwright/test';
+
+export class SearchListPage {
+  private page: Page;
+  readonly priceSale :Locator;
+  readonly priceRegular :Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.priceSale = page.locator('[class="dfd-card-price dfd-card-price--sale"]')
+    this.priceRegular = page.locator('[class="dfd-card-price"]')
+  }
+
+
+  async priceItem(): Promise<string> {
+    let price: string | null;
+    if (await this.priceSale.count() > 0) {
+      price = await this.priceSale.first().textContent();
+    }
+    else{
+      price = await this.priceRegular.first().textContent();
+    }
+    if (price === null) {
+      throw new Error(`Price not found`);
+    }
+
+    return price;
+  }
+}

--- a/scraper/providers/druni.ts
+++ b/scraper/providers/druni.ts
@@ -1,0 +1,32 @@
+import { parsePriceToEuros } from '../function/common';
+import { LOG_EVENT, logger, normalizeLogError } from '../utils/logger';
+import { ScraperFn } from '../utils/types';
+import { CookiesPage } from '../page/druni/cookiesPage';
+import { HomePage } from '../page/druni/homePage';
+import { SearchListPage } from '../page/druni/searchListPage';
+
+export const druniScraper: ScraperFn = async ({context,productId }) => {
+
+  try {
+    logger.info({ event: LOG_EVENT.PROVIDER_SCRAPE_STARTED, provider: 'druni', productId }, 'Starting Druni scraper');
+
+    const page = await context.newPage();
+    await page.goto('https://www.druni.es/');
+    const cookiesPage = new CookiesPage(page);
+    const homePage = new HomePage(page);
+    const searchListPage = new SearchListPage(page);
+    
+    await cookiesPage.clickRejectButton();
+    await homePage.searchForReference(productId);
+    const rawPrice = await searchListPage.priceItem();
+
+    const price = parsePriceToEuros(rawPrice);
+    logger.info({ event: LOG_EVENT.PROVIDER_PRICE_OBTAINED, provider: 'druni', productId, price }, 'Price obtained from Druni');
+    return price;
+  } catch (error) {
+    logger.error({ event: LOG_EVENT.PROVIDER_SCRAPE_FAILED, provider: 'druni', productId, error: normalizeLogError(error) }, 'Druni scraper failed');
+    throw error;
+  } finally {
+    await context.close();
+  }
+};

--- a/scraper/utils/providers.ts
+++ b/scraper/utils/providers.ts
@@ -1,3 +1,4 @@
 export const AMAZON_PROVIDER_ID:number = 1;
 export const CARREFOUR_PROVIDER_ID:number = 2;
 export const PRIMOR_PROVIDER_ID:number = 3;
+export const DRUNI_PROVIDER_ID:number = 4;


### PR DESCRIPTION
## Summary

Add support for **Druni** as a new price scraping provider.

## Changes

- Added `druniScraper` and registered it in the product processing flow.
- Implemented the required Page Objects for Druni.
- Added the scraping logic to:
  - Search for a product by reference.
  - Extract its price.
  - Parse the price into the internal format.
- Added the new `DRUNI_PROVIDER_ID`.

## Impact

The scraping service now supports Druni alongside the existing providers, following the current scraper architecture.