### PR TITLE
[#51] Feature: Enhance documentation for tenant scrapers and add guid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,43 @@
 
 <img src="./assets/logo.png" alt="Scoopy Logo" width="350"/>
 
+**Price tracking platform for product monitoring and history analysis**
 
-
-**Amazon and e-commerce price tracking platform**
-
-Scoopy is a price monitoring platform focused on tracking product prices from Amazon and potentially other online retailers.
-
-The main goal of this project is to collect historical price data, store it, and expose it through APIs that can later be consumed by a frontend application for visualization and analysis.
+Scoopy collects product prices from multiple tenants, stores the historical data in the database, and exposes it through an API that can be consumed by the frontend.
 
 </div>
 
 ---
 
-## Features
+## Overview
 
-* Scrape Amazon product prices.
-* Store historical price information.
-* Expose APIs to query price history data.
-* Designed to support multiple vendors in the future.
-* Backend prepared for integration with a web frontend.
+Scoopy is split into three main parts:
+
+- [Frontend](frontend/README.md) for the user interface and data visualization.
+- [Scoopy API](scoopy-api/README.md) for the Rails backend that exposes product and price history data.
+- [Scraper](scraper/README.md) for the Playwright-based automation that collects tenant prices and stores them in PostgreSQL.
+
+Each part has its own README with the detailed setup, structure, and behavior of that subproject.
+
+## What Scoopy Does
+
+At a high level, Scoopy works like this:
+
+1. The scraper reads product identifiers from the database and visits each tenant site.
+2. The scraper extracts the current price and stores it in the historical price tables.
+3. The API serves the stored products and price history to clients.
+4. The frontend presents that information in a user-friendly interface.
+
+The goal is to centralize price monitoring so the project can track changes over time and make the data easy to inspect.
 
 ## Project Structure
 
 ```text
 Scoopy/
 ├── assets/
-│   └── logo.png
-├── scraper/   # Amazon web scraper and price collection logic
-├── scoopy-api/        # REST APIs for accessing stored data
+├── frontend/
+├── scraper/
+├── scoopy-api/
 └── README.md
 ```
 
@@ -39,9 +48,17 @@ Scoopy/
 
 ```mermaid
 flowchart LR
-    A[Amazon Website] --> B[Scraper]
-    B --> C[(Database)]
-    C --> D[API]
-    D --> E[Frontend Application]
-    E --> F[End Users]
+    A[Tenant websites] --> B[Scraper]
+    B --> C[(PostgreSQL)]
+    C --> D[Scoopy API]
+    D --> E[Frontend]
+    E --> F[Users]
 ```
+
+## Documentation
+
+For the implementation details of each part, see:
+
+- [Frontend README](frontend/README.md)
+- [Scoopy API README](scoopy-api/README.md)
+- [Scraper README](scraper/README.md)

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,128 @@
+# Scraper
+
+This package contains the browser automation layer used by Scoopy to collect product prices from different tenants and persist them in PostgreSQL.
+
+The scraper is written in TypeScript and uses Playwright to drive real browser sessions. Each tenant has its own scraping flow because the search inputs, cookie dialogs, result selectors, and price widgets are different.
+
+## What This Scraper Does
+
+At a high level, the scraper:
+
+1. Reads a product identifier from the database or from the CLI.
+2. Chooses the correct tenant-specific scraper based on `provider_id`.
+3. Opens a Playwright browser context with a realistic user agent and browser flags.
+4. Navigates to the tenant site, handles cookies or modals, searches the product, and extracts the current price.
+5. Stores the resulting price in the `price_histories` table.
+
+The batch processor can iterate through all products in `providers_products`, while the single-product processor can scrape one product by its SSN and provider mapping.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[providers_products / CLI SSN] --> B[productProcessor]
+    B --> C{provider_id}
+    C --> D[Amazon scraper]
+    C --> E[Carrefour scraper]
+    C --> F[Druni scraper]
+    C --> G[Primor scraper]
+    D --> H[Price extraction]
+    E --> H
+    F --> H
+    G --> H
+    H --> I[(PostgreSQL price_histories)]
+```
+
+## Important Concepts
+
+- `SSN`: the internal product key stored in `providers_products.ssn`. The CLI uses this value to resolve the target tenant and product record.
+- `provider_id`: the numeric tenant identifier used to pick the correct scraper implementation.
+- `product_id`: the UUID of the product record stored in the database.
+- `PLAYWRIGHTHEADLESS`: when set to `True`, the browser runs in headless mode. The code checks for the exact string `True`.
+- `SCRAPER_LOG_FILE`: optional file path for persistent logs. If configured, logs are written to that file in addition to the default output.
+
+## Tenant Guides
+
+Each tenant has its own detailed guide with the search flow, selectors, and the common ways to identify the product key used by the scraper.
+
+- [Amazon tenant guide](docs/tenants/amazon.md)
+- [Carrefour tenant guide](docs/tenants/carrefour.md)
+- [Druni tenant guide](docs/tenants/druni.md)
+- [Primor tenant guide](docs/tenants/primor.md)
+
+## Setup
+
+1. Install the package dependencies from this directory.
+2. Copy `example.env` to your local environment file and populate the PostgreSQL values.
+3. Make sure the database contains the `providers_products` records you want to scrape.
+
+Required environment variables:
+
+- `PGHOST`
+- `PGPORT`
+- `PGUSER`
+- `PGPASSWORD`
+- `PGDATABASE`
+
+Optional environment variables:
+
+- `PLAYWRIGHTHEADLESS`
+- `SCRAPER_LOG_FILE`
+
+## Manual Execution
+
+Build the TypeScript sources first:
+
+```bash
+cd scraper
+npm install
+```
+
+Run a single product scrape by SSN:
+from scoopy folder
+
+```bash
+npx tsx scraper/function/productProcessor.ts <SSN>                                
+```
+
+Run the batch processor for all products in the database:
+from scoopy folder
+```bash
+npx tsx scraper/function/productBatchProcessor.ts 
+```
+
+If you want browser windows visible while debugging, leave `PLAYWRIGHTHEADLESS` unset or set it to any value other than `True`.
+
+## Automatic Execution
+
+The recommended automation path is to compile the scraper and then schedule the batch processor.
+
+Typical production flow:
+
+1. Load the environment variables.
+2. Do an `npm install`.
+3. Run `npx tsx scraper/function/productBatchProcessor.ts ` on a schedule.
+
+Example cron job:
+Please have in mind that tenants may apply restrictions if too many request are run at the same time
+
+```cron
+0 * * * * cd /path/to/Scoopy  npx tsx scraper/function/productBatchProcessor.ts 
+```
+
+Use the scheduler that fits your deployment style best, such as `cron`, a systemd timer, a container job, or a platform scheduler. The important part is that the batch processor runs in an environment where the database credentials and Playwright runtime are available.
+
+## Product Notes Template
+
+Use this section to document product-specific behavior, edge cases, or search hints you discover later.
+
+| Product | Tenant | Identifier used | Search notes | Special cases |
+| --- | --- | --- | --- | --- |
+| Add your product here | Add tenant | Add SSN / reference | Add how to find it | Add exceptions |
+
+## Troubleshooting
+
+- If the scraper says the ASIN or SSN is missing, confirm the identifier exists in `providers_products`.
+- If the tenant site changes its HTML, the selectors in the corresponding tenant guide will need an update.
+- If the browser cannot connect to PostgreSQL, verify the `PG*` environment variables and the database network access.
+- If logs do not appear in a file, confirm `SCRAPER_LOG_FILE` points to a writable path.

--- a/scraper/docs/tenants/amazon.md
+++ b/scraper/docs/tenants/amazon.md
@@ -1,0 +1,42 @@
+# Amazon Tenant Guide
+
+This guide explains how the Amazon scraper works and how the product key is located for Amazon items.
+
+## Identifier Used
+
+Amazon uses the ASIN as the main search key.
+
+In practice, the scraper receives the value stored in `providers_products.ssn`, then searches that value in Amazon's search box and looks for a result card with the same `data-asin` attribute.
+
+## How the Scraper Finds the Product
+
+The flow is:
+
+1. Open `https://www.amazon.es/`.
+2. Accept the cookie prompt.
+3. Fill the top search input with the ASIN.
+4. Submit the search.
+5. Locate the result item whose `data-asin` matches the searched ASIN.
+6. Read the current price from the matching result card.
+
+The relevant selectors are:
+
+- Search input: `#twotabsearchtextbox`
+- Search button: `#nav-search-submit-button`
+- Result item: `[data-asin="<asin>"][role="listitem"]`
+- Price inside the item: `span[data-a-size="xl"][data-a-color="base"].a-price`
+
+## Ways to Find the ASIN
+
+Common ways to identify the Amazon ASIN are:
+
+1. From the product URL, where the ASIN usually appears in the path or query string.
+2. From the product detail page HTML or page source.
+3. From Amazon search results, where the same ASIN is exposed in the result item attributes.
+4. From the internal Scoopy mapping stored in the database when the product has already been linked to Amazon.
+
+## Notes
+
+- The scraper reads the price from the search results page instead of opening a product detail page.
+- If several results appear, the scraper only trusts the result whose `data-asin` exactly matches the searched ASIN.
+- If Amazon changes the markup, both the result locator and the price selector may need to be updated together.

--- a/scraper/docs/tenants/carrefour.md
+++ b/scraper/docs/tenants/carrefour.md
@@ -1,0 +1,40 @@
+# Carrefour Tenant Guide
+
+This guide explains the Carrefour search flow and the different ways to identify the product reference used by the scraper.
+
+## Identifier Used
+
+Carrefour is searched using the product reference stored in `providers_products.ssn`.
+
+The scraper does not transform this value. It sends the stored reference to Carrefour's search field and expects the tenant search engine to resolve the corresponding product result.
+
+## How the Scraper Finds the Product
+
+The flow is:
+
+1. Open `https://www.carrefour.es/`.
+2. Reject the cookie prompt.
+3. Click the search bar.
+4. Type the reference.
+5. Submit the search with `Enter`.
+6. Read the current price from the search result card.
+
+The relevant selectors are:
+
+- Search container: `#search-input`
+- Search input: `input[type="search"]`
+- Search button: `[data-test="search-button"]`
+- Current price card: `[data-test="result-current-price"]`
+
+## Ways to Find the Reference
+
+Common ways to identify the Carrefour reference are:
+
+1. By searching the product name on Carrefour.
+2. Looking in the url and at the end there should be a code like X-XXXXXXXXX-XXXXXX
+
+## Notes
+
+- The current implementation includes short waits after cookie handling and search actions because Carrefour is sensitive to timing.
+- The scraper reads the current result price directly from the search results page.
+- If Carrefour changes the search UI, the timing and selectors are the first places to update.

--- a/scraper/docs/tenants/druni.md
+++ b/scraper/docs/tenants/druni.md
@@ -1,0 +1,41 @@
+# Druni Tenant Guide
+
+This guide explains the Druni search flow and how to locate the product reference used by the scraper.
+
+## Identifier Used
+
+Druni is searched using the product reference stored in `providers_products.ssn`.
+
+The scraper enters that value into Druni's search field, submits the search, and then reads the current price from the search results page.
+
+## How the Scraper Finds the Product
+
+The flow is:
+
+1. Open `https://www.druni.es/`.
+2. Reject the cookie prompt.
+3. Open the search area.
+4. Type the product reference.
+5. Submit the search with `Enter`.
+6. Read the current price from the search results.
+
+The relevant selectors are:
+
+- Search entry point: `#search-input`
+- Search input: `input[type="search"]`
+- Search button: `[data-test="search-button"]`
+- Current price: `[data-test="result-current-price"]`
+
+## Ways to Find the Reference
+
+Common ways to identify the Druni reference are:
+
+1. By searching the product on Druni so just 1 option appear.
+2. Open the inspector and search for sku.
+3. There will be a `<script>` with the product information.
+4. Copy the sku value
+
+## Notes
+
+- The scraper currently reads the first current-price result returned by the search results page.
+- If Druni changes the search markup, the `data-test` attributes will likely need to be updated.

--- a/scraper/docs/tenants/primor.md
+++ b/scraper/docs/tenants/primor.md
@@ -1,0 +1,44 @@
+# Primor Tenant Guide
+
+This guide explains the Primor search flow and the different ways to identify the product reference used by the scraper.
+
+## Identifier Used
+
+Primor is searched using the product reference stored in `providers_products.ssn`.
+
+The scraper sends that value to Primor's search input, submits the search, and reads the visible result price.
+
+## How the Scraper Finds the Product
+
+The flow is:
+
+1. Open `https://www.primor.eu/es_es/`.
+2. Close the initial continuation modal by clicking `Continuar`.
+3. Click the search input.
+4. Type the product reference.
+5. Click the search button.
+6. Read the visible product price from the results card.
+
+The relevant selectors are:
+
+- Search input: `[data-test="search-input"]`
+- Search button: `[data-test="search-button"]`
+- Sale price card: `[class="dfd-card-price dfd-card-price--sale"]`
+- Regular price card: `[class="dfd-card-price"]`
+
+## Ways to Find the Reference
+
+Common ways to identify the Primor reference are:
+
+1. From the Primor site search for the product so just 1 appear.
+2. Open the network tab in the devtools panel.
+3. Reload the search page.
+4. search for `https://api.empathy.co/search/v1/query/primor/search?`
+5. Go to preview
+6. Go to catalog > content > element position 
+7. And get the sku property value
+
+## Notes
+
+- The scraper prefers the sale price when it exists, and falls back to the regular price otherwise.
+- If Primor changes the card structure, both price selectors may need to be adjusted.


### PR DESCRIPTION
## Summary

Improve the project documentation by adding dedicated guides for the scraper and each supported provider.

## Changes

- Updated the root `README.md` with a project overview, architecture, and links to subproject documentation.
- Added a dedicated `scraper/README.md` covering:
  - Architecture and workflow.
  - Setup and configuration.
  - Manual and scheduled execution.
  - Troubleshooting.
- Added tenant guides for:
  - Amazon
  - Carrefour
  - Druni
  - Primor
- Documented the search flow, product identifiers, selectors, and notes for each supported provider.

## Impact

The project documentation is now more structured, making it easier to understand the architecture, configure the scraper, and maintain or extend provider implementations.